### PR TITLE
run when sls offline is explicitly passed the `start` cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ dependencies will be added as expected. Development/peer dependencies are ignore
 The plugin will run when you do:
 - A full deployment (`sls deploy`)
 - Deployment of individual functions (`sls deploy -f`)
+- Spinning up a local sandbox with [serverless-offline](https://github.com/dherault/serverless-offline) (`sls offline [start]`)
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class ServerlessMonoRepo {
     this.hooks = {
       'package:cleanup': () => this.clean(),
       'package:initialize': () => this.initialise(),
+      'offline:start:init': () => this.initialise(),
       'offline:start': () => this.initialise(),
       'deploy:function:initialize': async () => {
         await this.clean()


### PR DESCRIPTION
Serverless Offline injects different hooks depending on whether its `start` command is issued implicitly or explicitly :roll_eyes: Generate symlinks, regardless, in case forced to use the explicit format (`sls offline start`).