### PR TITLE
fix(issue-16: added additional error code check

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ const getNodeModulePaths = p => {
   return result
 }
 
-// Creates a symlink. Ignores if fails to create due to already existing.
+// Creates a symlink. Ignore errors if symlink exists or package exists.
 async function link (target, f, type) {
   await fs.ensureDir(path.dirname(f))
   await fs.symlink(target, f, type)
     .catch(e => {
-      if (e.code === 'EEXIST') {
+      if (e.code === 'EEXIST'|| e.code === 'EISDIR') {
         return
       }
       throw e


### PR DESCRIPTION
Added additional error code check.  It now continues if the symlink already exists OR if a directory of the same name exists (the package is already installed).

Fixes /Butterwire/serverless-plugin-monorepo/#16