### PR TITLE
Confirm support for v2 and v3 versions of a Framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fs-extra": "^9.0.1"
   },
   "peerDependencies": {
-    "serverless": "1.x"
+    "serverless": "1 || 2"
   },
   "engines": {
     "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fs-extra": "^9.0.1"
   },
   "peerDependencies": {
-    "serverless": "1 || 2"
+    "serverless": "1 || 2 || 3"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Peer dependency setting suggests plugin supports only v1 version of a Framework.  While it appears that plugin works without issues with v2. 

This patch fixes the configuration, which otherwise enforces package managers (as npm v7) to install outdated Framework version for plugin exclusively.