### PR TITLE
chore: mark plugin as Serverless Framework v4 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fs-extra": "^9.0.1"
   },
   "peerDependencies": {
-    "serverless": "1 || 2 || 3"
+    "serverless": "1 || 2 || 3 || 4"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Working well with Serverless Framework v4 as well.